### PR TITLE
Various fixes from lmms

### DIFF
--- a/tap_autopan.c
+++ b/tap_autopan.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 /* The Unique ID of the plugin: */
@@ -231,10 +231,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	int i;
 	char ** port_names;
@@ -339,9 +339,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_chorusflanger.c
+++ b/tap_chorusflanger.c
@@ -23,7 +23,7 @@
 #include <math.h>
 #include <time.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -434,10 +434,10 @@ LADSPA_Descriptor * stereo_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -573,9 +573,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(stereo_descriptor);
 }
 

--- a/tap_deesser.c
+++ b/tap_deesser.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 /* The Unique ID of the plugin: */
@@ -347,10 +347,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	int i;
 	char ** port_names;
@@ -469,9 +469,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_doubler.c
+++ b/tap_doubler.c
@@ -23,7 +23,7 @@
 #include <math.h>
 #include <time.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -572,10 +572,10 @@ LADSPA_Descriptor * stereo_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -715,9 +715,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(stereo_descriptor);
 }
 

--- a/tap_dynamics_m.c
+++ b/tap_dynamics_m.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -184,7 +184,7 @@ get_table_gain(int mode, LADSPA_Data level) {
 	LADSPA_Data y1 = -80.0f;
 	LADSPA_Data x2 = 0.0f;
 	LADSPA_Data y2 = 0.0f;
-	int i = 0;
+	unsigned int i = 0;
 
 	if (level <= -80.0f)
 		return get_table_gain(mode, -79.9f);
@@ -514,10 +514,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -644,9 +644,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_dynamics_st.c
+++ b/tap_dynamics_st.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -202,7 +202,7 @@ get_table_gain(int mode, LADSPA_Data level) {
 	LADSPA_Data y1 = -80.0f;
 	LADSPA_Data x2 = 0.0f;
 	LADSPA_Data y2 = 0.0f;
-	int i = 0;
+	unsigned int i = 0;
 
 	if (level <= -80.0f)
 		return get_table_gain(mode, -79.9f);
@@ -694,10 +694,10 @@ LADSPA_Descriptor * stereo_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -855,9 +855,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(stereo_descriptor);
 }
 

--- a/tap_echo.c
+++ b/tap_echo.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 /* The Unique ID of the plugin: */
@@ -131,7 +131,7 @@ void
 activate_Echo(LADSPA_Handle Instance) {
 
 	Echo * ptr = (Echo *)Instance;
-	int i;
+	unsigned int i;
 	
 	ptr->mpx_out_L = 0;
 	ptr->mpx_out_R = 0;
@@ -434,10 +434,10 @@ LADSPA_Descriptor * stereo_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -605,9 +605,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(stereo_descriptor);
 }
 

--- a/tap_eq.c
+++ b/tap_eq.c
@@ -27,7 +27,7 @@ bugs or malfunction. */
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 /* The Unique ID of the plugin */
@@ -143,9 +143,8 @@ activate_eq(LADSPA_Handle instance) {
 static
 void
 cleanup_eq(LADSPA_Handle instance) {
-
-        eq *plugin_data = (eq *)instance;
-        free(plugin_data->filters);
+	eq *plugin_data = (eq *)instance;
+	free(plugin_data->filters);
 	free(instance);
 }
 
@@ -494,7 +493,7 @@ run_adding_eq(LADSPA_Handle instance, unsigned long sample_count) {
 
 
 void
-_init() {
+__attribute__((constructor)) tap_init() {
 
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
@@ -765,7 +764,7 @@ _init() {
 
 
 void 
-_fini() {
+__attribute__((destructor)) tap_fini() {
 
 	if (eqDescriptor) {
 		free((LADSPA_PortDescriptor *)eqDescriptor->PortDescriptors);

--- a/tap_eqbw.c
+++ b/tap_eqbw.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 /* The Unique ID of the plugin */
@@ -165,9 +165,8 @@ activate_eq(LADSPA_Handle instance) {
 static
 void
 cleanup_eq(LADSPA_Handle instance) {
-
-        eq *plugin_data = (eq *)instance;
-        free(plugin_data->filters);
+	eq *plugin_data = (eq *)instance;
+	free(plugin_data->filters);
 	free(instance);
 }
 
@@ -596,7 +595,7 @@ run_adding_eq(LADSPA_Handle instance, unsigned long sample_count) {
 
 
 void
-_init() {
+__attribute__((constructor)) tap_init() {
 
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
@@ -955,7 +954,7 @@ _init() {
 
 
 void 
-_fini() {
+__attribute__((destructor)) tap_fini() {
 
 	if (eqDescriptor) {
 		free((LADSPA_PortDescriptor *)eqDescriptor->PortDescriptors);

--- a/tap_pinknoise.c
+++ b/tap_pinknoise.c
@@ -23,7 +23,7 @@
 #include <math.h>
 #include <time.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 /* The Unique ID of the plugin: */
@@ -223,10 +223,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -235,9 +235,6 @@ _init() {
 	if ((mono_descriptor = 
 	     (LADSPA_Descriptor *)malloc(sizeof(LADSPA_Descriptor))) == NULL)
 		exit(1);
-
-	/* initialize RNG */
-	srand(time(0));
 
 	mono_descriptor->UniqueID = ID_MONO;
 	mono_descriptor->Label = strdup("tap_pinknoise");
@@ -323,9 +320,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_pinknoise.c
+++ b/tap_pinknoise.c
@@ -236,6 +236,11 @@ __attribute__((constructor)) tap_init() {
 	     (LADSPA_Descriptor *)malloc(sizeof(LADSPA_Descriptor))) == NULL)
 		exit(1);
 
+#ifndef TAP_DISABLE_SRAND
+	/* initialize RNG */
+	srand(time(0));
+#endif
+
 	mono_descriptor->UniqueID = ID_MONO;
 	mono_descriptor->Label = strdup("tap_pinknoise");
 	mono_descriptor->Properties = LADSPA_PROPERTY_HARD_RT_CAPABLE;

--- a/tap_pitch.c
+++ b/tap_pitch.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -416,10 +416,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	int i;
 	char ** port_names;
@@ -534,9 +534,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_reflector.c
+++ b/tap_reflector.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -376,10 +376,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	int i;
 	char ** port_names;
@@ -478,9 +478,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_reverb.c
+++ b/tap_reverb.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 
 
 /* ***** VERY IMPORTANT! *****
@@ -70,7 +70,7 @@ load_plugin_data(LADSPA_Handle Instance) {
 
 	Reverb * ptr = (Reverb *)Instance;
 	unsigned long m;
-	int i;
+	unsigned int i;
 
 
 	m = LIMIT(*(ptr->mode),0,NUM_MODES-1);
@@ -191,7 +191,7 @@ void
 comp_coeffs(LADSPA_Handle Instance) {
 
 	Reverb * ptr = (Reverb *)Instance;
-	int i;
+	unsigned int i;
 	
 
 	if (*(ptr->mode) != ptr->old_mode)
@@ -412,7 +412,7 @@ run_Reverb(LADSPA_Handle Instance,
 	Reverb * ptr = (Reverb *)Instance;
 
 	unsigned long sample_index;
-	int i;
+	unsigned int i;
 
 	LADSPA_Data decay = LIMIT(*(ptr->decay),0.0f,10000.0f);
 	LADSPA_Data drylevel = db2lin(LIMIT(*(ptr->drylevel),-70.0f,10.0f));
@@ -531,7 +531,7 @@ run_adding_gain_Reverb(LADSPA_Handle Instance,
 	Reverb * ptr = (Reverb *)Instance;
 
 	unsigned long sample_index;
-	int i;
+	unsigned int i;
 
 	LADSPA_Data decay = LIMIT(*(ptr->decay),0.0f,10000.0f);
 	LADSPA_Data drylevel = db2lin(LIMIT(*(ptr->drylevel),-70.0f,10.0f));
@@ -663,10 +663,10 @@ LADSPA_Descriptor * stereo_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -813,9 +813,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(stereo_descriptor);
 }
 

--- a/tap_rotspeak.c
+++ b/tap_rotspeak.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 /* The Unique ID of the plugin: */
@@ -114,59 +114,92 @@ typedef struct {
 } RotSpkr;
 
 
+void cleanup_RotSpkr(LADSPA_Handle Instance);
 
 /* Construct a new plugin instance. */
-LADSPA_Handle 
+LADSPA_Handle
 instantiate_RotSpkr(const LADSPA_Descriptor * Descriptor,
 		    unsigned long             sample_rate) {
-	
+
 	LADSPA_Handle * ptr;
-	
-	if ((ptr = malloc(sizeof(RotSpkr))) != NULL) {
-		((RotSpkr *)ptr)->sample_rate = sample_rate;
-		((RotSpkr *)ptr)->run_adding_gain = 1.0;
 
-                if ((((RotSpkr *)ptr)->ringbuffer_h_L =
-                     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
-                        return NULL;
-                if ((((RotSpkr *)ptr)->ringbuffer_h_R =
-                     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
-                        return NULL;
-                ((RotSpkr *)ptr)->buflen_h_L = ceil(0.3f * sample_rate / M_PI);
-                ((RotSpkr *)ptr)->buflen_h_R = ceil(0.3f * sample_rate / M_PI);
-                ((RotSpkr *)ptr)->pos_h_L = 0;
-                ((RotSpkr *)ptr)->pos_h_R = 0;
+	if ((ptr = calloc(1, sizeof(RotSpkr))) != NULL) {
+		RotSpkr* rotSpeak = (RotSpkr*)ptr;
+		rotSpeak->sample_rate = sample_rate;
+		rotSpeak->run_adding_gain = 1.0;
 
-                if ((((RotSpkr *)ptr)->ringbuffer_b_L =
-                     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
-                        return NULL;
-                if ((((RotSpkr *)ptr)->ringbuffer_b_R =
-                     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
-                        return NULL;
-                ((RotSpkr *)ptr)->buflen_b_L = ceil(0.3f * sample_rate / M_PI);
-                ((RotSpkr *)ptr)->buflen_b_R = ceil(0.3f * sample_rate / M_PI);
-                ((RotSpkr *)ptr)->pos_b_L = 0;
-                ((RotSpkr *)ptr)->pos_b_R = 0;
+		if ((rotSpeak->ringbuffer_h_L =
+		     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
+			return NULL;
+		}
+		if ((rotSpeak->ringbuffer_h_R =
+		     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
+			return NULL;
+		}
+		rotSpeak->buflen_h_L = ceil(0.3f * sample_rate / M_PI);
+		rotSpeak->buflen_h_R = ceil(0.3f * sample_rate / M_PI);
+		rotSpeak->pos_h_L = 0;
+		rotSpeak->pos_h_R = 0;
 
-		if ((((RotSpkr *)ptr)->eq_filter_L = calloc(1, sizeof(biquad))) == NULL)
+		if ((rotSpeak->ringbuffer_b_L =
+		     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
 			return NULL;
-		if ((((RotSpkr *)ptr)->lp_filter_L = calloc(1, sizeof(biquad))) == NULL)
+		}
+		if ((rotSpeak->ringbuffer_b_R =
+		     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
 			return NULL;
-		if ((((RotSpkr *)ptr)->hp_filter_L = calloc(1, sizeof(biquad))) == NULL)
+		}
+		rotSpeak->buflen_b_L = ceil(0.3f * sample_rate / M_PI);
+		rotSpeak->buflen_b_R = ceil(0.3f * sample_rate / M_PI);
+		rotSpeak->pos_b_L = 0;
+		rotSpeak->pos_b_R = 0;
+
+		if ((rotSpeak->eq_filter_L = calloc(1, sizeof(biquad))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
 			return NULL;
-		
-		if ((((RotSpkr *)ptr)->eq_filter_R = calloc(1, sizeof(biquad))) == NULL)
+		}
+		if ((rotSpeak->lp_filter_L = calloc(1, sizeof(biquad))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
 			return NULL;
-		if ((((RotSpkr *)ptr)->lp_filter_R = calloc(1, sizeof(biquad))) == NULL)
+		}
+		if ((rotSpeak->hp_filter_L = calloc(1, sizeof(biquad))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
 			return NULL;
-		if ((((RotSpkr *)ptr)->hp_filter_R = calloc(1, sizeof(biquad))) == NULL)
+		}
+
+		if ((rotSpeak->eq_filter_R = calloc(1, sizeof(biquad))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
 			return NULL;
-		
+		}
+		if ((rotSpeak->lp_filter_R = calloc(1, sizeof(biquad))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
+			return NULL;
+		}
+		if ((rotSpeak->hp_filter_R = calloc(1, sizeof(biquad))) == NULL)
+		{
+			cleanup_RotSpkr((LADSPA_Handle)rotSpeak);
+			return NULL;
+		}
+
 		return ptr;
 	}
-	
+
 	return NULL;
 }
+
 
 void
 activate_RotSpkr(LADSPA_Handle Instance) {
@@ -204,13 +237,13 @@ activate_RotSpkr(LADSPA_Handle Instance) {
 
 
 /* Connect a port to a data location. */
-void 
+void
 connect_port_RotSpkr(LADSPA_Handle Instance,
 		     unsigned long Port,
 		     LADSPA_Data * DataLocation) {
-	
+
 	RotSpkr * ptr;
-	
+
 	ptr = (RotSpkr *)Instance;
 	switch (Port) {
 	case HORNFREQ:
@@ -227,7 +260,7 @@ connect_port_RotSpkr(LADSPA_Handle Instance,
 		break;
 	case LATENCY:
 		ptr->latency = DataLocation;
-                *(ptr->latency) = ptr->buflen_h_L / 2;  /* IS THIS LEGAL? */
+                *(ptr->latency) = ptr->buflen_h_L / 2;  /* IS THIS LEGAL? YES, ONLY IF DataLocation points to valid memory location on stack/heap*/
 		break;
 	case INPUT_L:
 		ptr->input_L = DataLocation;
@@ -246,10 +279,10 @@ connect_port_RotSpkr(LADSPA_Handle Instance,
 
 
 
-void 
+void
 run_RotSpkr(LADSPA_Handle Instance,
 	    unsigned long SampleCount) {
-  
+
 	RotSpkr * ptr = (RotSpkr *)Instance;
 
 	LADSPA_Data * input_L = ptr->input_L;
@@ -549,23 +582,38 @@ run_adding_RotSpkr(LADSPA_Handle Instance,
 
 
 
-/* Throw away an RotSpkr effect instance. */
-void 
+/*
+   Throw away an RotSpkr effect instance.
+   This function should be called only when RotSpkr was allocated with calloc.
+ */
+void
 cleanup_RotSpkr(LADSPA_Handle Instance) {
 
-        RotSpkr * ptr = (RotSpkr *)Instance;
-
-	free(ptr->ringbuffer_h_L);
-	free(ptr->ringbuffer_h_R);
-	free(ptr->ringbuffer_b_L);
-	free(ptr->ringbuffer_b_R);
-	free(ptr->eq_filter_L);
-	free(ptr->eq_filter_R);
-	free(ptr->lp_filter_L);
-	free(ptr->lp_filter_R);
-	free(ptr->hp_filter_L);
-	free(ptr->hp_filter_R);
-	free(Instance);
+	RotSpkr * ptr = (RotSpkr *)Instance;
+	if (!ptr)
+		return;
+	if (ptr->ringbuffer_h_L)
+		free(ptr->ringbuffer_h_L);
+	if (ptr->ringbuffer_h_R)
+		free(ptr->ringbuffer_h_R);
+	if (ptr->ringbuffer_b_L)
+		free(ptr->ringbuffer_b_L);
+	if (ptr->ringbuffer_b_R)
+		free(ptr->ringbuffer_b_R);
+	if (ptr->eq_filter_L)
+		free(ptr->eq_filter_L);
+	if (ptr->eq_filter_R)
+		free(ptr->eq_filter_R);
+	if (ptr->lp_filter_L)
+		free(ptr->lp_filter_L);
+	if (ptr->lp_filter_R)
+		free(ptr->lp_filter_R);
+	if (ptr->hp_filter_L)
+		free(ptr->hp_filter_L);
+	if (ptr->hp_filter_R)
+		free(ptr->hp_filter_R);
+	if (Instance)
+		free(Instance);
 }
 
 
@@ -574,10 +622,10 @@ LADSPA_Descriptor * stereo_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	int i;
 	char ** port_names;
@@ -698,9 +746,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(stereo_descriptor);
 }
 

--- a/tap_sigmoid.c
+++ b/tap_sigmoid.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -226,10 +226,10 @@ cleanup_Sigmoid(LADSPA_Handle Instance) {
 LADSPA_Descriptor * mono_descriptor = NULL;
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -316,9 +316,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_tremolo.c
+++ b/tap_tremolo.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 /* The Unique ID of the plugin: */
@@ -218,10 +218,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -321,9 +321,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_tubewarmth.c
+++ b/tap_tubewarmth.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -379,10 +379,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	char ** port_names;
 	LADSPA_PortDescriptor * port_descriptors;
@@ -469,9 +469,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 

--- a/tap_vibrato.c
+++ b/tap_vibrato.c
@@ -1,6 +1,6 @@
 /*                                                     -*- linux-c -*-
     Copyright (C) 2004 Tom Szilagyi
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "ladspa.h"
+#include <ladspa.h>
 #include "tap_utils.h"
 
 
@@ -83,19 +83,22 @@ typedef struct {
 
 
 /* Construct a new plugin instance. */
-LADSPA_Handle 
+LADSPA_Handle
 instantiate_Vibrato(const LADSPA_Descriptor * Descriptor,
 		    unsigned long             sample_rate) {
-  
-        LADSPA_Handle * ptr;
-	
+
+	LADSPA_Handle * ptr;
+
 	if ((ptr = malloc(sizeof(Vibrato))) != NULL) {
 		((Vibrato *)ptr)->sample_rate = sample_rate;
 		((Vibrato *)ptr)->run_adding_gain = 1.0f;
 
-		if ((((Vibrato *)ptr)->ringbuffer = 
+		if ((((Vibrato *)ptr)->ringbuffer =
 		     calloc(2 * PM_DEPTH, sizeof(LADSPA_Data))) == NULL)
+		{
+			free(ptr);
 			return NULL;
+		}
 		((Vibrato *)ptr)->buflen = ceil(0.2f * sample_rate / M_PI);
 		((Vibrato *)ptr)->pos = 0;
 
@@ -303,10 +306,10 @@ LADSPA_Descriptor * mono_descriptor = NULL;
 
 
 
-/* _init() is called automatically when the plugin library is first
+/* __attribute__((constructor)) tap_init() is called automatically when the plugin library is first
    loaded. */
 void 
-_init() {
+__attribute__((constructor)) tap_init() {
 	
 	int i;
 	char ** port_names;
@@ -420,9 +423,9 @@ delete_descriptor(LADSPA_Descriptor * descriptor) {
 }
 
 
-/* _fini() is called automatically when the library is unloaded. */
+/* __attribute__((destructor)) tap_fini() is called automatically when the library is unloaded. */
 void
-_fini() {
+__attribute__((destructor)) tap_fini() {
 	delete_descriptor(mono_descriptor);
 }
 


### PR DESCRIPTION
First, thanks for the plugins!  And second, hi from LMMS!

We've been bundling the `tap-plugins` for quite some time but we've been pretty bad about sending our patches back.

We have an initiative to move all of our plugin code back to the upstream maintainers, so that this won't happen anymore. :) I hope this PR is well received.

The changes are pretty small, so I've placed them all into one commit.

I did not author these changes, however they are needed (especially the constructors/destructors) to use an upstream source mirror.  We support several build systems including Linux, BSD, Apple and Windows (gcc and clang for now), so patches are driven primary by 1. Making them work and 2. Compiler warnings.  Reviewing the changes, I can observe one that appears to be a styling change as well.  I hope this is OK.  I can move that to a separate PR if needed.

The downstream documented fixes that we have are (should jump to relevant snippet):
1. Fix compiler warnings: https://github.com/LMMS/lmms/commit/52d4f0fd3fd31fb3b5b926e742b9fbede740a742#diff-4e4adf4e4277f5cc6565de9d9b200bb4
1. Don't mis-initialize rand with default value: https://github.com/LMMS/lmms/commit/570159868eb4fd6f4417e71888be395e2089b174#diff-11fbde16f5d448c9161be2e1017296a4
1. Misc code cleanup: https://github.com/LMMS/lmms/commit/2049e00901ebdf5929bb3d7bc5acf2c41a42ad49#diff-769b5878579023b42826f5addfba09bc
1. Fix instantiation/destruction: https://github.com/LMMS/lmms/commit/83c20196117f0b3519479c7bb736bc1a45e19619#diff-41c1bb33908f8e8f520fb7b1b0b5958b
1. Fix memory leak: https://github.com/LMMS/lmms/commit/ddbb1808001c6ff128118f4e62fd89261f05bccd#diff-602c24fe9eeb819fedb642682d941b5b

Any changes needed, please let me know.  I'd also be willing to split commits and/or PRs if that makes it easier.